### PR TITLE
Set Serial TimeOut to 10ms

### DIFF
--- a/src/LD2450.cpp
+++ b/src/LD2450.cpp
@@ -34,6 +34,7 @@ void LD2450::begin(HardwareSerial &radarStream, bool already_initialized)
     if (!already_initialized)
     {
         radarStream.begin(LD2450_SERIAL_SPEED);
+        radarStream.setTimeout(10);
     }
 
     LD2450::radar_uart = &radarStream;
@@ -47,6 +48,7 @@ void LD2450::begin(HardwareSerial &radarStream, bool already_initialized)
         if (!already_initialized)
         {
             radarStream.begin(LD2450_SERIAL_SPEED);
+            radarStream.setTimeout(10);
         }
     
         LD2450::radar_uart = &radarStream;


### PR DESCRIPTION
Default Serial Timeout is 1000ms, which causes the Arduino to be blocked and process the incoming data to ~1 per second.
Setting the Serial TimeOut to 10ms improves performance and allows the Arduino to process the 10 frames of data per second. 